### PR TITLE
Update gitlab-grit dependency to 2.7.1

### DIFF
--- a/grit_adapter.gemspec
+++ b/grit_adapter.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.description = %q{Adapter for Gollum to use Grit at the backend.}
   s.license	= "MIT"
 
-  s.add_runtime_dependency 'gitlab-grit', '~> 2.6.5'
+  s.add_runtime_dependency 'gitlab-grit', '~> 2.7.1'
   s.add_development_dependency "rspec", "2.13.0"
 
   s.files         = Dir['lib/**/*.rb'] + ["README.md", "Gemfile"]


### PR DESCRIPTION
Changes to gitlab-grit since 2.6.5 included below.

== 2.7.1
- Suppress 'unkown header' warnings
- Add process.out to CommandFailed error

== 2.7.0
- Remove the `chdir:` option for thread-safety
- Automatically set the `--work-tree=` Git option

== 2.6.9
- Fix commit diff issue. It shows empty diff for commit when files
- have changed mode

== 2.6.8
- Fix problem with generating archives

== 2.6.7
- Rescue compatibility errors

== 2.6.6
- Improve encoding
