### PR TITLE
Allow push/pull through to underlying grit object

### DIFF
--- a/lib/grit_adapter/git_layer_grit.rb
+++ b/lib/grit_adapter/git_layer_grit.rb
@@ -203,6 +203,14 @@ module Gollum
         end
       end
 
+      def push(*args)
+        @git.push(args)
+      end
+
+      def pull(*args)
+        @git.pull(args)
+      end
+
       private
 
       def log(path = nil, ref = nil, options = nil, *args)


### PR DESCRIPTION
The current grit_adaptor breaks automatic pulls/pushes using the method described at https://github.com/gollum/gollum-lib/issues/12#issuecomment-24854800

This pull request allows push/pull through to the underlying Grit::Git object.