### PR TITLE
Abstract revert behavior.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 rvm:
-- 1.9.3
 - 2.0.0
-- 2.1.0
 - 2.1.1
+- 2.2.1
+- 2.3.0
 before_install:
 - sudo apt-get update
 - sudo apt-get install libicu-dev

--- a/lib/grit_adapter/git_layer_grit.rb
+++ b/lib/grit_adapter/git_layer_grit.rb
@@ -170,7 +170,7 @@ module Gollum
       def revert(path, sha1, sha2, ref)
         patch = path ?
           repo.diff(sha2, sha1, path).first.diff : repo.diff(sha2, sha1).map { |d| d.diff }.join("\n")
-        apply_patch(ref, patch)
+        @git.apply_patch({}, ref, patch)
       end
       
       def ls_files(query, options = {})
@@ -226,10 +226,6 @@ module Gollum
 
       def repo
         @repo ||= Grit::Repo.new(@git.git_dir)
-      end
-
-      def apply_patch(ref, patch=nil)
-        @git.apply_patch({}, ref, patch)
       end
       
     end

--- a/lib/grit_adapter/git_layer_grit.rb
+++ b/lib/grit_adapter/git_layer_grit.rb
@@ -166,6 +166,12 @@ module Gollum
       rescue Grit::GitRuby::Repository::NoSuchShaFound
         raise Gollum::Git::NoSuchShaFound
       end
+
+      def revert(path, sha1, sha2, ref)
+        patch = path ?
+          repo.diff(sha2, sha1, path).first.diff : repo.diff(sha2, sha1).map { |d| d.diff }.join("\n")
+        apply_patch(ref, patch)
+      end
       
       def ls_files(query, options = {})
         ref = options[:ref] ? options[:ref] : "HEAD"
@@ -181,10 +187,6 @@ module Gollum
       
       def ls_tree(options={}, *args, &block)
         @git.native(:ls_tree, options, *args, &block)
-      end
-      
-      def apply_patch(head_sha=nil, patch=nil)
-        @git.apply_patch({}, head_sha, patch)
       end
       
       # @repo.git.cat_file({:p => true}, sha)
@@ -224,6 +226,10 @@ module Gollum
 
       def repo
         @repo ||= Grit::Repo.new(@git.git_dir)
+      end
+
+      def apply_patch(ref, patch=nil)
+        @git.apply_patch({}, ref, patch)
       end
       
     end


### PR DESCRIPTION
Implement a `Git#revert` method so we can abstract from the low-level grit calls in gollum-lib.