### PR TITLE
Allow gitlab-grit 2.8 and above

### DIFF
--- a/grit_adapter.gemspec
+++ b/grit_adapter.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.description = %q{Adapter for Gollum to use Grit at the backend.}
   s.license	= "MIT"
 
-  s.add_runtime_dependency 'gitlab-grit', '~> 2.7', '>= 2.7.1'
+  s.add_runtime_dependency 'gitlab-grit', '>= 2.7.1'
   s.add_development_dependency "rspec", "3.4.0"
 
   s.files         = Dir['lib/**/*.rb'] + ["README.md", "Gemfile"]


### PR DESCRIPTION
gitlab-grit 2.7 and lower required version 1.x of the mime-types gem which has a lot of much-needed
updates recently.

See: 
- https://rubygems.org/gems/gitlab-grit/versions/2.7.3
- https://rubygems.org/gems/gitlab-grit/versions/2.8.1
- https://github.com/mime-types/ruby-mime-types/blob/master/History.rdoc